### PR TITLE
fix xox game winning search algorithm

### DIFF
--- a/XOX/XOXGame/XOXGame.swift
+++ b/XOX/XOXGame/XOXGame.swift
@@ -118,6 +118,8 @@ struct XOXGame {
                 if diagonalDownCount >= pieceMatchCountToWin {
                     return true
                 }
+            } else {
+                break
             }
             
             
@@ -140,6 +142,8 @@ struct XOXGame {
                 if diagonalDownCount >= pieceMatchCountToWin {
                     return true
                 }
+            } else {
+                break
             }
             
             
@@ -169,6 +173,8 @@ struct XOXGame {
                 if diagonalUpCount >= pieceMatchCountToWin {
                     return true
                 }
+            } else {
+                break
             }
             
             
@@ -191,6 +197,8 @@ struct XOXGame {
                 if diagonalUpCount >= pieceMatchCountToWin {
                     return true
                 }
+            } else {
+                break
             }
             
             
@@ -214,6 +222,8 @@ struct XOXGame {
                 if horizontalCount >= pieceMatchCountToWin {
                     return true
                 }
+            } else {
+                break
             }
             
             
@@ -235,6 +245,8 @@ struct XOXGame {
                 if verticalCount >= pieceMatchCountToWin {
                     return true
                 }
+            } else {
+                break
             }
             
             


### PR DESCRIPTION
- problem: when the rows and columns are set to 4 or 5, and the piece matched count is 3, the game declare winner even if there are different piece on the way as along as the count in the path is 3.
- solution: break the search and return false immediately when a different piece is in the way